### PR TITLE
Restart waitpid if it returns with EINTR

### DIFF
--- a/src/runsync.cc
+++ b/src/runsync.cc
@@ -78,7 +78,7 @@ int SpawnRunner::RunParent() {
             }
         }
     } else {
-        waitpid(pid_, &status, 0);
+        while (waitpid(pid_, &status, 0) == -1 && errno == EINTR);
     }
     return status;
 }


### PR DESCRIPTION
In some situations waitpid() in kernel can be interrupted so it will return retcode=-1,errno=EINTR _before_ target process really exits. The suggested way is just restart waitpid().
